### PR TITLE
CallbackIteratorInterface Improvement

### DIFF
--- a/src/CallbackIteratorInterface.php
+++ b/src/CallbackIteratorInterface.php
@@ -29,4 +29,12 @@ interface CallbackIteratorInterface extends Iterator
      * @return callable The callback of this iterator.
      */
     public function getCallback();
+
+    /**
+     * Return the current element after applying the callback to it.
+     *
+     * @see getCallback()
+     * @since [*next-version*]
+     */
+    public function current();
 }

--- a/src/CallbackIteratorInterface.php
+++ b/src/CallbackIteratorInterface.php
@@ -8,9 +8,6 @@ use Iterator;
  * Something that can act as a callback iterator.
  *
  * A callback iterator is something that returns items processed by a callback.
- * The {@see current()} method MUST return the result of applying the callback
- * to the current item.
- * See {@see getCallback()} for defails about the callback.
  *
  * @since [*next-version*]
  */


### PR DESCRIPTION
- `current()` method now explicitly required due to interface specifics;
- Docs corrected.
