### PR TITLE
Fix Wrong Return Typehint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[*next-version*]] - YYYY-MM-DD
+### Fixed
+- Absence of return typehint for `MapFactoryInterface` (#32).
 
 ## [0.4.0-alpha1] - 2024-09-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[*next-version*]] - YYYY-MM-DD
 ### Fixed
-- Absence of return typehint for `MapFactoryInterface` (#32).
+- Wrong return typehint for `MapFactoryInterface`
+  and `WritableMapFactoryInterface` (#32).
 
 ## [0.4.0-alpha1] - 2024-09-21
 ### Added

--- a/src/MapFactoryInterface.php
+++ b/src/MapFactoryInterface.php
@@ -23,5 +23,5 @@ interface MapFactoryInterface extends ContainerFactoryInterface
      *
      * @throws Exception If problem creating.
      */
-    public function createContainerFromArray(array $data): BaseContainerInterface;
+    public function createContainerFromArray(array $data): MapInterface;
 }

--- a/src/MapFactoryInterface.php
+++ b/src/MapFactoryInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Dhii\Collection;
 
 use Exception;
-use Psr\Container\ContainerInterface as BaseContainerInterface;
 
 /**
  * A factory that can create maps.

--- a/src/WritableMapFactoryInterface.php
+++ b/src/WritableMapFactoryInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Dhii\Collection;
 
-use Psr\Container\ContainerInterface as BaseContainerInterface;
-
 /**
  * Creates writable maps.
  *
@@ -18,5 +16,5 @@ interface WritableMapFactoryInterface extends WritableContainerFactoryInterface,
      *
      * @return WritableMapInterface The new map.
      */
-    public function createContainerFromArray(array $data): BaseContainerInterface;
+    public function createContainerFromArray(array $data): WritableMapInterface;
 }


### PR DESCRIPTION
- Addresses #30.
	This is a non-breaking change according to spec, as the PHPDoc already had the right type. However, the formal PHP return typehint has become narrower, which may cause BC problems.

	⚠️ Therefore, this is to be considered a BC-breaking change.