### PR TITLE
Rename parameter for compat with `ContainerInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[*next-version*]] - YYYY-MM-DD
+### Changed
+- Aligned param names with those of PSR interfaces (#37).
 
 ## [0.5.0-beta1] - 2026-03-23
 ### Changed

--- a/src/HasCapableInterface.php
+++ b/src/HasCapableInterface.php
@@ -14,7 +14,7 @@ interface HasCapableInterface
     /**
      * Determines whether this instance has the specified key.
      *
-     * @param string $key The key to check for.
+     * @param string $id The key to check for.
      *
      * @return bool True if the key exists; false otherwise.
      *
@@ -23,5 +23,5 @@ interface HasCapableInterface
      * @psalm-suppress PossiblyUnusedMethod
      * @psalm-suppress InvalidThrow
      */
-    public function has(string $key): bool;
+    public function has(string $id): bool;
 }


### PR DESCRIPTION
Otherwise, this breaks named params.